### PR TITLE
Update imports to take OS into account

### DIFF
--- a/supergen/base/linux_core.py
+++ b/supergen/base/linux_core.py
@@ -19,8 +19,10 @@
 # Authors:
 #     Alberto Pérez García-Plaza <alpgarcia@gmail.com>
 #
-import pyudev
-import psutil
+import platform
+if platform.system() == 'Linux':
+    import pyudev
+    import psutil
 
 from time import sleep
 

--- a/supergen/base/osx_core.py
+++ b/supergen/base/osx_core.py
@@ -20,9 +20,11 @@
 #     Alberto Pérez García-Plaza <alpgarcia@gmail.com>
 #
 import os
+import platform
 
 from time import sleep
-from subprocess import Popen, PIPE
+if platform.system() == 'Darwin':
+    from subprocess import Popen, PIPE
 
 from supergen.base.core import Core
 

--- a/supergen/base/windows_core.py
+++ b/supergen/base/windows_core.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2019 Alberto Pérez García-Plaza
+# Copyright (C) 2019 Marcos Nieto Doncel
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,11 +17,13 @@
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #
 # Authors:
-#     Alberto Pérez García-Plaza <alpgarcia@gmail.com>
+#     Marcos Nieto Doncel
 #
-import win32file
+import platform
+import time
+if platform.system() == 'Windows':
+    import win32file
 
-import time, string
 
 from supergen.base.core import Core
 


### PR DESCRIPTION
Fixes the problem of running unit tests from operative systems
where some libraries are not available. Check the platform
on each system dependent import before importing. As unit tests
shouldn't be affected by system calls (that should be mocked)
this should work.